### PR TITLE
Keep source format of re-written file, preserve BOM and/or CRLF

### DIFF
--- a/tests/keep_source_format_test.py
+++ b/tests/keep_source_format_test.py
@@ -5,25 +5,25 @@ from absolufy_imports import main
 
 
 def test_bom(tmpdir):
-    os.mkdir(os.path.join(str(tmpdir), "mypackage"))
-    os.mkdir(os.path.join(str(tmpdir), "mypackage", "mysubpackage"))
+    os.mkdir(os.path.join(str(tmpdir), 'mypackage'))
+    os.mkdir(os.path.join(str(tmpdir), 'mypackage', 'mysubpackage'))
     tmp_file = os.path.join(
         str(tmpdir),
-        "mypackage",
-        "mysubpackage",
-        "bar.py",
+        'mypackage',
+        'mysubpackage',
+        'bar.py',
     )
     # write file with a BOM at start
-    with open(os.path.join("tests", "data", "bar.py"), "rb") as src:
-        with open(tmp_file, "wb") as dst:
-            dst.write("\ufeff".encode("utf-8"))
+    with open(os.path.join('tests', 'data', 'bar.py'), 'rb') as src:
+        with open(tmp_file, 'wb') as dst:
+            dst.write('\ufeff'.encode())
             dst.write(src.read())
 
     cwd = os.getcwd()
     os.chdir(str(tmpdir))
     try:
         main(
-            (os.path.join("mypackage", "mysubpackage", "bar.py"),),
+            (os.path.join('mypackage', 'mysubpackage', 'bar.py'),),
         )
     finally:
         os.chdir(cwd)
@@ -32,55 +32,55 @@ def test_bom(tmpdir):
         result = fd.read()
 
     expected = (
-        "\ufeff"
-        "from mypackage.mysubpackage import B\n"
-        "from mypackage.mysubpackage.bar import baz\n"
-        "from mypackage.foo import T\n"
-        "from mypackage.mysubpackage.bar import D\n"
-        "from mypackage.mysubpackage import O\n"
-        "from datetime import datetime\n"
-        "\n"
-        "print(T)\n"
-        "print(D)\n"
+        '\ufeff'
+        'from mypackage.mysubpackage import B\n'
+        'from mypackage.mysubpackage.bar import baz\n'
+        'from mypackage.foo import T\n'
+        'from mypackage.mysubpackage.bar import D\n'
+        'from mypackage.mysubpackage import O\n'
+        'from datetime import datetime\n'
+        '\n'
+        'print(T)\n'
+        'print(D)\n'
     )
     assert result == expected
 
 
 def test_crlf(tmpdir):
-    os.mkdir(os.path.join(str(tmpdir), "mypackage"))
-    os.mkdir(os.path.join(str(tmpdir), "mypackage", "mysubpackage"))
+    os.mkdir(os.path.join(str(tmpdir), 'mypackage'))
+    os.mkdir(os.path.join(str(tmpdir), 'mypackage', 'mysubpackage'))
     tmp_file = os.path.join(
         str(tmpdir),
-        "mypackage",
-        "mysubpackage",
-        "bar.py",
+        'mypackage',
+        'mysubpackage',
+        'bar.py',
     )
     # re-write as CRLF
-    with open(os.path.join("tests", "data", "bar.py")) as src:
-        with open(tmp_file, "w", newline="\r\n") as dst:
+    with open(os.path.join('tests', 'data', 'bar.py')) as src:
+        with open(tmp_file, 'w', newline='\r\n') as dst:
             dst.write(src.read())
 
     cwd = os.getcwd()
     os.chdir(str(tmpdir))
     try:
         main(
-            (os.path.join("mypackage", "mysubpackage", "bar.py"),),
+            (os.path.join('mypackage', 'mysubpackage', 'bar.py'),),
         )
     finally:
         os.chdir(cwd)
 
-    with open(tmp_file, newline="") as fd:
+    with open(tmp_file, newline='') as fd:
         result = fd.read()
 
     expected = (
-        "from mypackage.mysubpackage import B\r\n"
-        "from mypackage.mysubpackage.bar import baz\r\n"
-        "from mypackage.foo import T\r\n"
-        "from mypackage.mysubpackage.bar import D\r\n"
-        "from mypackage.mysubpackage import O\r\n"
-        "from datetime import datetime\r\n"
-        "\r\n"
-        "print(T)\r\n"
-        "print(D)\r\n"
+        'from mypackage.mysubpackage import B\r\n'
+        'from mypackage.mysubpackage.bar import baz\r\n'
+        'from mypackage.foo import T\r\n'
+        'from mypackage.mysubpackage.bar import D\r\n'
+        'from mypackage.mysubpackage import O\r\n'
+        'from datetime import datetime\r\n'
+        '\r\n'
+        'print(T)\r\n'
+        'print(D)\r\n'
     )
     assert result == expected

--- a/tests/keep_source_format_test.py
+++ b/tests/keep_source_format_test.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 from absolufy_imports import main
 

--- a/tests/keep_source_format_test.py
+++ b/tests/keep_source_format_test.py
@@ -1,0 +1,86 @@
+import os
+import shutil
+
+from absolufy_imports import main
+
+
+def test_bom(tmpdir):
+    os.mkdir(os.path.join(str(tmpdir), "mypackage"))
+    os.mkdir(os.path.join(str(tmpdir), "mypackage", "mysubpackage"))
+    tmp_file = os.path.join(
+        str(tmpdir),
+        "mypackage",
+        "mysubpackage",
+        "bar.py",
+    )
+    # write file with a BOM at start
+    with open(os.path.join("tests", "data", "bar.py"), "rb") as src:
+        with open(tmp_file, "wb") as dst:
+            dst.write("\ufeff".encode("utf-8"))
+            dst.write(src.read())
+
+    cwd = os.getcwd()
+    os.chdir(str(tmpdir))
+    try:
+        main(
+            (os.path.join("mypackage", "mysubpackage", "bar.py"),),
+        )
+    finally:
+        os.chdir(cwd)
+
+    with open(tmp_file) as fd:
+        result = fd.read()
+
+    expected = (
+        "\ufeff"
+        "from mypackage.mysubpackage import B\n"
+        "from mypackage.mysubpackage.bar import baz\n"
+        "from mypackage.foo import T\n"
+        "from mypackage.mysubpackage.bar import D\n"
+        "from mypackage.mysubpackage import O\n"
+        "from datetime import datetime\n"
+        "\n"
+        "print(T)\n"
+        "print(D)\n"
+    )
+    assert result == expected
+
+
+def test_crlf(tmpdir):
+    os.mkdir(os.path.join(str(tmpdir), "mypackage"))
+    os.mkdir(os.path.join(str(tmpdir), "mypackage", "mysubpackage"))
+    tmp_file = os.path.join(
+        str(tmpdir),
+        "mypackage",
+        "mysubpackage",
+        "bar.py",
+    )
+    # re-write as CRLF
+    with open(os.path.join("tests", "data", "bar.py")) as src:
+        with open(tmp_file, "w", newline="\r\n") as dst:
+            dst.write(src.read())
+
+    cwd = os.getcwd()
+    os.chdir(str(tmpdir))
+    try:
+        main(
+            (os.path.join("mypackage", "mysubpackage", "bar.py"),),
+        )
+    finally:
+        os.chdir(cwd)
+
+    with open(tmp_file, newline="") as fd:
+        result = fd.read()
+
+    expected = (
+        "from mypackage.mysubpackage import B\r\n"
+        "from mypackage.mysubpackage.bar import baz\r\n"
+        "from mypackage.foo import T\r\n"
+        "from mypackage.mysubpackage.bar import D\r\n"
+        "from mypackage.mysubpackage import O\r\n"
+        "from datetime import datetime\r\n"
+        "\r\n"
+        "print(T)\r\n"
+        "print(D)\r\n"
+    )
+    assert result == expected


### PR DESCRIPTION
This PR aims to preserve the source file format consistent by preserving BOM (if present) and/or CRFL line feeds found on Windows.

Closes #45