### PR TITLE
Feature: Add `--depth N` for controlling relative depth when absolufying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.xml
 *.egg-info/
 build/
 dist/
+.idea/

--- a/README.md
+++ b/README.md
@@ -72,3 +72,44 @@ $ absolufy-imports mypackage/myfile.py --never
 - from mypackage import __version__
 + from . import __version__
 ```
+
+### Depth (default: 0)
+Don't absolufy relative import less or equal to the specified depth.
+
+Usage: `--depth N` with `N` as integer.
+
+* `--never` and `--depth N` are mutally exclusive
+
+Folder:
+```
+mypackage
+    | mysubpackage
+    |   | __init__.py
+    |   | example.py
+    | __init__.py
+    | main.py
+```
+
+`__init__.py` content:
+```
+from .example import __file__
+from ..main import __file__
+```
+
+Examples:
+* `$ absolufy-imports mypackage/mysubpackage/__init__.py --depth 1`
+
+```diff
+  from .example import __file__
+- from ..main import __file__
++ from mypackage.main import __file__
+```
+
+* `$ absolufy-imports mypackage/mysubpackage/__init__.py --depth 0 # default value`
+
+```diff
+- from .example import __file__
++ from mypackage.mysubpackage.example import __file__
+- from ..main import __file__
++ from mypackage.main import __file__
+```

--- a/README.md
+++ b/README.md
@@ -74,29 +74,27 @@ $ absolufy-imports mypackage/myfile.py --never
 ```
 
 ### Depth (default: 0)
-Don't absolufy relative import less or equal to the specified depth.
+
+Don't absolufy (backward or forward) relative imports less or equal to the specified depth.
 
 Usage: `--depth N` with `N` as integer.
 
-* `--never` and `--depth N` are mutally exclusive
+* `--never` and `--depth N` are mutually exclusive
+
+In other words, when choosing `--depth 1` you can only use relative
+imports for files/folder in the same package. See above examples
 
 Folder:
 ```
 mypackage
-    | mysubpackage
-    |   | __init__.py
-    |   | example.py
-    | __init__.py
-    | main.py
+ |-- mysubpackage
+ |   |-- __init__.py
+ |   |-- example.py
+ |-- __init__.py
+ |-- main.py
 ```
 
-`__init__.py` content:
-```
-from .example import __file__
-from ..main import __file__
-```
-
-Examples:
+#### Examples (backward: `from ..X import A`) with `--depth 1`:
 * `$ absolufy-imports mypackage/mysubpackage/__init__.py --depth 1`
 
 ```diff
@@ -104,7 +102,6 @@ Examples:
 - from ..main import __file__
 + from mypackage.main import __file__
 ```
-
 * `$ absolufy-imports mypackage/mysubpackage/__init__.py --depth 0 # default value`
 
 ```diff
@@ -112,4 +109,24 @@ Examples:
 + from mypackage.mysubpackage.example import __file__
 - from ..main import __file__
 + from mypackage.main import __file__
+```
+
+With: `mypackage.mysubpackage.__init__.py` content:
+```
+from .example import __file__ # 1 level, same folder
+from ..main import __file__ # 2 levels, parent folder
+```
+
+#### Example (forward: `from .X.Y.Z import A`) with `--depth 1`:
+
+* `$ absolufy-imports mypackage/__init__.py --depth 1`
+```diff
+- from .mysubpackage.__init__ import __file__
++ from mypackage.mysubpackage.__init__ import __file__
+```
+
+With `mypackage.__init__.py` content:
+```
+from .mysubpackage.__init__ import __file__
+from .mysubpackage import __init__ as i
 ```

--- a/absolufy_imports.py
+++ b/absolufy_imports.py
@@ -81,7 +81,9 @@ class Visitor(ast.NodeVisitor):
             self.to_replace[
                 node.lineno
             ] = (rf'(from\s+){"."*level}\s*', f'\\1{absolute_import} ')
-        elif node.module and never:
+        elif node.module is not None and never \
+                or node.module is not None \
+                and len(node.module.split('.')) > self.depth_level:
             # e.g. from .b import c
             module = node.module
             self.to_replace[

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = absolufy_imports
-version = 0.3.1
+version = 0.3.2
 description = A tool to automatically replace relative imports with absolute ones.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/data/depth.py
+++ b/tests/data/depth.py
@@ -1,0 +1,11 @@
+from mypackage.mysubpackage import already_absolute
+from mypackage.mysubpackage import already_absolute as f
+from .foo.bar import baz
+from .foo.bar.baz import baz
+from ..foo import T
+from .bar import D
+from . import O
+from datetime import datetime
+
+print(T)
+print(D)

--- a/tests/depth_test.py
+++ b/tests/depth_test.py
@@ -8,10 +8,10 @@ def test_depth(tmpdir):
     os.mkdir(os.path.join(str(tmpdir), 'mypackage'))
     os.mkdir(os.path.join(str(tmpdir), 'mypackage', 'mysubpackage'))
     tmp_file = os.path.join(
-        str(tmpdir), 'mypackage', 'mysubpackage', 'bar.py',
+        str(tmpdir), 'mypackage', 'mysubpackage', 'depth.py',
     )
     shutil.copy(
-        os.path.join('tests', 'data', 'bar.py'), tmp_file,
+        os.path.join('tests', 'data', 'depth.py'), tmp_file,
     )
 
     cwd = os.getcwd()
@@ -19,7 +19,7 @@ def test_depth(tmpdir):
     try:
         main(
             (
-                os.path.join('mypackage', 'mysubpackage', 'bar.py'),
+                os.path.join('mypackage', 'mysubpackage', 'depth.py'),
                 '--depth',
                 '1',
             ),
@@ -29,10 +29,11 @@ def test_depth(tmpdir):
 
     with open(tmp_file) as fd:
         result = fd.read()
-
     expected = (
-        'from mypackage.mysubpackage import B\n'
-        'from mypackage.mysubpackage.bar import baz\n'
+        'from mypackage.mysubpackage import already_absolute\n'
+        'from mypackage.mysubpackage import already_absolute as f\n'
+        'from mypackage.mysubpackage.foo.bar import baz\n'
+        'from mypackage.mysubpackage.foo.bar.baz import baz\n'
         'from mypackage.foo import T\n'
         'from .bar import D\n'
         'from . import O\n'

--- a/tests/depth_test.py
+++ b/tests/depth_test.py
@@ -1,0 +1,44 @@
+import os
+import shutil
+
+from absolufy_imports import main
+
+
+def test_depth(tmpdir):
+    os.mkdir(os.path.join(str(tmpdir), 'mypackage'))
+    os.mkdir(os.path.join(str(tmpdir), 'mypackage', 'mysubpackage'))
+    tmp_file = os.path.join(
+        str(tmpdir), 'mypackage', 'mysubpackage', 'bar.py',
+    )
+    shutil.copy(
+        os.path.join('tests', 'data', 'bar.py'), tmp_file,
+    )
+
+    cwd = os.getcwd()
+    os.chdir(str(tmpdir))
+    try:
+        main(
+            (
+                os.path.join('mypackage', 'mysubpackage', 'bar.py'),
+                '--depth',
+                '1',
+            ),
+        )
+    finally:
+        os.chdir(cwd)
+
+    with open(tmp_file) as fd:
+        result = fd.read()
+
+    expected = (
+        'from mypackage.mysubpackage import B\n'
+        'from mypackage.mysubpackage.bar import baz\n'
+        'from mypackage.foo import T\n'
+        'from .bar import D\n'
+        'from . import O\n'
+        'from datetime import datetime\n'
+        '\n'
+        'print(T)\n'
+        'print(D)\n'
+    )
+    assert result == expected


### PR DESCRIPTION
Hello, @MarcoGorelli Thank you for the project, very cool! 👍 

We would like to suggest this feature which will provide a fine-grained control for absolufying imports.

Feature:
* add `--depth N` option (default to 0, normal behavior)

For example:
* with `--depth 1` you can specify to absolufy  `from .. import X` and to keep `from . import X`. 
 `--depth 1` meaning we keep at least 1 level of relative import 
  * Keep `from .` or `from .foo
  * Absolufy: `from ..` or `from .foo.bar`
 
This setting allows (for example) to build architectures of packages using only 1 level of relative imports.

We are opened to suggestions so don't hesitate to request any change.
